### PR TITLE
fix: prevent double-free when closing Aeron client with live child handles

### DIFF
--- a/rusteron-archive/docs-rs/aeron.rs
+++ b/rusteron-archive/docs-rs/aeron.rs
@@ -205,6 +205,23 @@ impl<T> std::fmt::Debug for CResource<T> {
         }
     }
 }
+#[doc = " A type-erased, allocation-free handle to an *owning* client's \"close already called\""]
+#[doc = " flag."]
+#[doc = ""]
+#[doc = " The Aeron C client owns every publication/subscription/counter it creates and frees"]
+#[doc = " them all when the client itself is closed. To avoid a double free / use-after-free,"]
+#[doc = " each child resource carries one of these (as a dependency) pointing at its owning"]
+#[doc = " client's flag. On drop the child can then cheaply ask \"has my owner already been"]
+#[doc = " closed?\" via [`ManagedCResource::owner_already_closed`] without dereferencing its own"]
+#[doc = " (by then freed) C pointer."]
+#[doc = ""]
+#[doc = " The pointer aliases the `close_already_called` [`std::cell::Cell`] living inside the"]
+#[doc = " owner's [`ManagedCResource`]. It is kept valid because the same child also holds an"]
+#[doc = " `Rc` dependency on the owning client (added alongside this handle), so the owner's"]
+#[doc = " `ManagedCResource` — and therefore the `Cell` — outlives this handle. It is only ever"]
+#[doc = " read from the child's `drop`, while those dependencies are still alive."]
+#[derive(Clone)]
+pub struct OwnerClosed(pub *const std::cell::Cell<bool>);
 #[doc = " A custom struct for managing C resources with automatic cleanup."]
 #[doc = ""]
 #[doc = " It handles initialisation and clean-up of the resource and ensures that resources"]
@@ -321,6 +338,28 @@ impl<T> ManagedCResource<T> {
                 .iter()
                 .filter_map(|x| x.as_ref().downcast_ref::<V>().cloned())
                 .next()
+        }
+    }
+    #[doc = " Returns an allocation-free handle to this resource's \"close already called\" flag so"]
+    #[doc = " it can be shared with child resources (see [`OwnerClosed`]). All clones of a wrapper"]
+    #[doc = " share the same underlying [`ManagedCResource`], hence the same flag, so closing the"]
+    #[doc = " client through any handle is observed by every child."]
+    #[inline]
+    pub fn closed_indicator(&self) -> OwnerClosed {
+        OwnerClosed(&self.close_already_called as *const std::cell::Cell<bool>)
+    }
+    #[doc = " Returns `true` if an owning client (registered as an [`OwnerClosed`] dependency)"]
+    #[doc = " has already been closed. When the owning Aeron/Archive client closes it frees this"]
+    #[doc = " resource's underlying C memory, so the resource must neither call its own C close"]
+    #[doc = " fn again nor read its C pointer. This check only reads rust-side flags and never"]
+    #[doc = " touches the C resource, so it is safe even after the owner has freed it."]
+    #[inline]
+    pub fn owner_already_closed(&self) -> bool {
+        unsafe {
+            (*self.dependencies.get())
+                .iter()
+                .filter_map(|d| d.as_ref().downcast_ref::<OwnerClosed>())
+                .any(|owner| !owner.0.is_null() && (*owner.0).get())
         }
     }
     #[inline]
@@ -1498,6 +1537,9 @@ impl AeronArchiveAsyncConnect {
         let result = Self {
             inner: CResource::OwnedOnHeap(std::rc::Rc::new(resource_async)),
         };
+        if let Some(__owner) = ctx.inner.as_owned() {
+            result.inner.add_dependency(__owner.closed_indicator());
+        }
         result.inner.add_dependency(ctx.clone());
         Ok(result)
     }
@@ -3251,20 +3293,21 @@ impl From<aeron_archive_control_response_poller_t> for AeronArchiveControlRespon
 impl Drop for AeronArchiveControlResponsePoller {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!(
-                        "{} not closed",
-                        stringify!(AeronArchiveControlResponsePoller)
-                    );
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!(
+                            "{} not closed",
+                            stringify!(AeronArchiveControlResponsePoller)
+                        );
+                    }
                 }
             }
         }
@@ -5205,20 +5248,21 @@ impl From<aeron_archive_persistent_subscription_t> for AeronArchivePersistentSub
 impl Drop for AeronArchivePersistentSubscription {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!(
-                        "{} not closed",
-                        stringify!(AeronArchivePersistentSubscription)
-                    );
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!(
+                            "{} not closed",
+                            stringify!(AeronArchivePersistentSubscription)
+                        );
+                    }
                 }
             }
         }
@@ -7023,20 +7067,21 @@ impl From<aeron_archive_recording_descriptor_poller_t> for AeronArchiveRecording
 impl Drop for AeronArchiveRecordingDescriptorPoller {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!(
-                        "{} not closed",
-                        stringify!(AeronArchiveRecordingDescriptorPoller)
-                    );
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!(
+                            "{} not closed",
+                            stringify!(AeronArchiveRecordingDescriptorPoller)
+                        );
+                    }
                 }
             }
         }
@@ -7962,20 +8007,21 @@ impl From<aeron_archive_recording_subscription_descriptor_poller_t>
 impl Drop for AeronArchiveRecordingSubscriptionDescriptorPoller {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!(
-                        "{} not closed",
-                        stringify!(AeronArchiveRecordingSubscriptionDescriptorPoller)
-                    );
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!(
+                            "{} not closed",
+                            stringify!(AeronArchiveRecordingSubscriptionDescriptorPoller)
+                        );
+                    }
                 }
             }
         }
@@ -11612,17 +11658,18 @@ impl From<aeron_archive_t> for AeronArchive {
 impl Drop for AeronArchive {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!("{} not closed", stringify!(AeronArchive));
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!("{} not closed", stringify!(AeronArchive));
+                    }
                 }
             }
         }
@@ -11887,6 +11934,9 @@ impl AeronAsyncAddCounter {
         let result = Self {
             inner: CResource::OwnedOnHeap(std::rc::Rc::new(resource_async)),
         };
+        if let Some(__owner) = client.inner.as_owned() {
+            result.inner.add_dependency(__owner.closed_indicator());
+        }
         result.inner.add_dependency(client.clone());
         Ok(result)
     }
@@ -12229,6 +12279,9 @@ impl AeronAsyncAddExclusivePublication {
         let result = Self {
             inner: CResource::OwnedOnHeap(std::rc::Rc::new(resource_async)),
         };
+        if let Some(__owner) = client.inner.as_owned() {
+            result.inner.add_dependency(__owner.closed_indicator());
+        }
         result.inner.add_dependency(client.clone());
         Ok(result)
     }
@@ -12539,6 +12592,9 @@ impl AeronAsyncAddPublication {
         let result = Self {
             inner: CResource::OwnedOnHeap(std::rc::Rc::new(resource_async)),
         };
+        if let Some(__owner) = client.inner.as_owned() {
+            result.inner.add_dependency(__owner.closed_indicator());
+        }
         result.inner.add_dependency(client.clone());
         Ok(result)
     }
@@ -12917,6 +12973,9 @@ impl AeronAsyncAddSubscription {
         let result = Self {
             inner: CResource::OwnedOnHeap(std::rc::Rc::new(resource_async)),
         };
+        if let Some(__owner) = client.inner.as_owned() {
+            result.inner.add_dependency(__owner.closed_indicator());
+        }
         result.inner.add_dependency(client.clone());
         Ok(result)
     }
@@ -17607,17 +17666,18 @@ impl From<aeron_counter_t> for AeronCounter {
 impl Drop for AeronCounter {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close_with_no_args();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!("{} not closed", stringify!(AeronCounter));
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close_with_no_args();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!("{} not closed", stringify!(AeronCounter));
+                    }
                 }
             }
         }
@@ -20409,17 +20469,18 @@ impl From<aeron_exclusive_publication_t> for AeronExclusivePublication {
 impl Drop for AeronExclusivePublication {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close_with_no_args();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!("{} not closed", stringify!(AeronExclusivePublication));
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close_with_no_args();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!("{} not closed", stringify!(AeronExclusivePublication));
+                    }
                 }
             }
         }
@@ -28233,17 +28294,18 @@ impl From<aeron_publication_t> for AeronPublication {
 impl Drop for AeronPublication {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close_with_no_args();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!("{} not closed", stringify!(AeronPublication));
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close_with_no_args();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!("{} not closed", stringify!(AeronPublication));
+                    }
                 }
             }
         }
@@ -31676,17 +31738,18 @@ impl From<aeron_subscription_t> for AeronSubscription {
 impl Drop for AeronSubscription {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close_with_no_args();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!("{} not closed", stringify!(AeronSubscription));
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close_with_no_args();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!("{} not closed", stringify!(AeronSubscription));
+                    }
                 }
             }
         }
@@ -35616,17 +35679,18 @@ impl From<aeron_uri_t> for AeronUri {
 impl Drop for AeronUri {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!("{} not closed", stringify!(AeronUri));
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!("{} not closed", stringify!(AeronUri));
+                    }
                 }
             }
         }

--- a/rusteron-archive/src/lib.rs
+++ b/rusteron-archive/src/lib.rs
@@ -967,6 +967,60 @@ mod tests {
         test_result
     }
 
+    /// Archive-side regression test for the close-then-drop double-free / use-after-free.
+    ///
+    /// In the archive crate the publications / exclusive publications / subscriptions /
+    /// counters are owned by the underlying `Aeron` client exactly as in the plain client
+    /// crate, so the same ownership/ordering bug applied: closing the `Aeron` client (which
+    /// in C frees every registered resource) while a resource handle was still alive used
+    /// to double-free / use-after-free when that handle dropped.
+    ///
+    /// Asserts the process survives closing the client BEFORE dropping the handles.
+    #[test]
+    #[serial]
+    pub fn archive_close_client_then_drop_resources_does_not_double_free(
+    ) -> Result<(), Box<dyn error::Error>> {
+        rusteron_code_gen::test_logger::init(log::LevelFilter::Info);
+        EmbeddedArchiveMediaDriverProcess::kill_all_java_processes()
+            .expect("failed to kill all java processes");
+
+        let (aeron, _archive_context, media_driver, mut pub_error_frame_handler, mut error_handler) =
+            start_aeron_archive()?;
+
+        let test_result: Result<(), Box<dyn error::Error>> = (|| {
+            // Acquire one of every client-owned resource type and keep the handles alive.
+            let publication =
+                aeron.add_publication(AERON_IPC_STREAM, 1001, Duration::from_secs(10))?;
+            let exclusive_publication =
+                aeron.add_exclusive_publication(AERON_IPC_STREAM, 1002, Duration::from_secs(10))?;
+            let subscription = aeron.add_subscription(
+                AERON_IPC_STREAM,
+                1003,
+                Handlers::no_available_image_handler(),
+                Handlers::no_unavailable_image_handler(),
+                Duration::from_secs(10),
+            )?;
+            let counter =
+                aeron.add_counter(101, &[1, 2, 3, 4], "test-counter", Duration::from_secs(10))?;
+
+            // Close the client FIRST; in C this frees every resource above.
+            aeron.close()?;
+
+            // Dropping the still-alive handles must NOT free them again.
+            drop(publication);
+            drop(exclusive_publication);
+            drop(subscription);
+            drop(counter);
+            Ok(())
+        })();
+
+        drop(aeron);
+        drop(media_driver);
+        pub_error_frame_handler.release();
+        error_handler.release();
+        test_result
+    }
+
     #[test]
     #[serial]
     fn test_invalid_recording_channel() -> Result<(), Box<dyn Error>> {

--- a/rusteron-client/docs-rs/aeron.rs
+++ b/rusteron-client/docs-rs/aeron.rs
@@ -259,6 +259,9 @@ impl AeronAsyncAddCounter {
         let result = Self {
             inner: CResource::OwnedOnHeap(std::rc::Rc::new(resource_async)),
         };
+        if let Some(__owner) = client.inner.as_owned() {
+            result.inner.add_dependency(__owner.closed_indicator());
+        }
         result.inner.add_dependency(client.clone());
         Ok(result)
     }
@@ -384,6 +387,23 @@ impl<T> std::fmt::Debug for CResource<T> {
         }
     }
 }
+#[doc = " A type-erased, allocation-free handle to an *owning* client's \"close already called\""]
+#[doc = " flag."]
+#[doc = ""]
+#[doc = " The Aeron C client owns every publication/subscription/counter it creates and frees"]
+#[doc = " them all when the client itself is closed. To avoid a double free / use-after-free,"]
+#[doc = " each child resource carries one of these (as a dependency) pointing at its owning"]
+#[doc = " client's flag. On drop the child can then cheaply ask \"has my owner already been"]
+#[doc = " closed?\" via [`ManagedCResource::owner_already_closed`] without dereferencing its own"]
+#[doc = " (by then freed) C pointer."]
+#[doc = ""]
+#[doc = " The pointer aliases the `close_already_called` [`std::cell::Cell`] living inside the"]
+#[doc = " owner's [`ManagedCResource`]. It is kept valid because the same child also holds an"]
+#[doc = " `Rc` dependency on the owning client (added alongside this handle), so the owner's"]
+#[doc = " `ManagedCResource` — and therefore the `Cell` — outlives this handle. It is only ever"]
+#[doc = " read from the child's `drop`, while those dependencies are still alive."]
+#[derive(Clone)]
+pub struct OwnerClosed(pub *const std::cell::Cell<bool>);
 #[doc = " A custom struct for managing C resources with automatic cleanup."]
 #[doc = ""]
 #[doc = " It handles initialisation and clean-up of the resource and ensures that resources"]
@@ -500,6 +520,28 @@ impl<T> ManagedCResource<T> {
                 .iter()
                 .filter_map(|x| x.as_ref().downcast_ref::<V>().cloned())
                 .next()
+        }
+    }
+    #[doc = " Returns an allocation-free handle to this resource's \"close already called\" flag so"]
+    #[doc = " it can be shared with child resources (see [`OwnerClosed`]). All clones of a wrapper"]
+    #[doc = " share the same underlying [`ManagedCResource`], hence the same flag, so closing the"]
+    #[doc = " client through any handle is observed by every child."]
+    #[inline]
+    pub fn closed_indicator(&self) -> OwnerClosed {
+        OwnerClosed(&self.close_already_called as *const std::cell::Cell<bool>)
+    }
+    #[doc = " Returns `true` if an owning client (registered as an [`OwnerClosed`] dependency)"]
+    #[doc = " has already been closed. When the owning Aeron/Archive client closes it frees this"]
+    #[doc = " resource's underlying C memory, so the resource must neither call its own C close"]
+    #[doc = " fn again nor read its C pointer. This check only reads rust-side flags and never"]
+    #[doc = " touches the C resource, so it is safe even after the owner has freed it."]
+    #[inline]
+    pub fn owner_already_closed(&self) -> bool {
+        unsafe {
+            (*self.dependencies.get())
+                .iter()
+                .filter_map(|d| d.as_ref().downcast_ref::<OwnerClosed>())
+                .any(|owner| !owner.0.is_null() && (*owner.0).get())
         }
     }
     #[inline]
@@ -1234,6 +1276,9 @@ impl AeronAsyncAddExclusivePublication {
         let result = Self {
             inner: CResource::OwnedOnHeap(std::rc::Rc::new(resource_async)),
         };
+        if let Some(__owner) = client.inner.as_owned() {
+            result.inner.add_dependency(__owner.closed_indicator());
+        }
         result.inner.add_dependency(client.clone());
         Ok(result)
     }
@@ -1544,6 +1589,9 @@ impl AeronAsyncAddPublication {
         let result = Self {
             inner: CResource::OwnedOnHeap(std::rc::Rc::new(resource_async)),
         };
+        if let Some(__owner) = client.inner.as_owned() {
+            result.inner.add_dependency(__owner.closed_indicator());
+        }
         result.inner.add_dependency(client.clone());
         Ok(result)
     }
@@ -1922,6 +1970,9 @@ impl AeronAsyncAddSubscription {
         let result = Self {
             inner: CResource::OwnedOnHeap(std::rc::Rc::new(resource_async)),
         };
+        if let Some(__owner) = client.inner.as_owned() {
+            result.inner.add_dependency(__owner.closed_indicator());
+        }
         result.inner.add_dependency(client.clone());
         Ok(result)
     }
@@ -6612,17 +6663,18 @@ impl From<aeron_counter_t> for AeronCounter {
 impl Drop for AeronCounter {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close_with_no_args();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!("{} not closed", stringify!(AeronCounter));
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close_with_no_args();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!("{} not closed", stringify!(AeronCounter));
+                    }
                 }
             }
         }
@@ -9221,17 +9273,18 @@ impl From<aeron_exclusive_publication_t> for AeronExclusivePublication {
 impl Drop for AeronExclusivePublication {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close_with_no_args();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!("{} not closed", stringify!(AeronExclusivePublication));
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close_with_no_args();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!("{} not closed", stringify!(AeronExclusivePublication));
+                    }
                 }
             }
         }
@@ -17045,17 +17098,18 @@ impl From<aeron_publication_t> for AeronPublication {
 impl Drop for AeronPublication {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close_with_no_args();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!("{} not closed", stringify!(AeronPublication));
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close_with_no_args();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!("{} not closed", stringify!(AeronPublication));
+                    }
                 }
             }
         }
@@ -20488,17 +20542,18 @@ impl From<aeron_subscription_t> for AeronSubscription {
 impl Drop for AeronSubscription {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close_with_no_args();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!("{} not closed", stringify!(AeronSubscription));
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close_with_no_args();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!("{} not closed", stringify!(AeronSubscription));
+                    }
                 }
             }
         }
@@ -24249,17 +24304,18 @@ impl From<aeron_uri_t> for AeronUri {
 impl Drop for AeronUri {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!("{} not closed", stringify!(AeronUri));
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!("{} not closed", stringify!(AeronUri));
+                    }
                 }
             }
         }

--- a/rusteron-client/src/lib.rs
+++ b/rusteron-client/src/lib.rs
@@ -353,6 +353,122 @@ mod tests {
         Ok(())
     }
 
+    /// Regression test for the double-free / use-after-free that occurred when an Aeron
+    /// client was closed while child resources (publication / exclusive publication /
+    /// subscription / counter) handles were still alive.
+    ///
+    /// The Aeron C client owns every registered resource and frees them all on
+    /// `aeron_close`. Previously rusteron would *also* free each resource when its Rust
+    /// handle dropped, so the `close()`-then-`drop()` ordering triggered a double free
+    /// (Linux: `free(): double free detected`; macOS: SIGSEGV/SIGABRT).
+    ///
+    /// This test asserts the process survives BOTH orderings:
+    ///   1. close the client first, then drop the handles (the previously crashing case);
+    ///   2. drop the handles first, then close the client (the always-worked case, which
+    ///      must still close everything exactly once and not leak).
+    #[test]
+    #[serial]
+    fn close_client_then_drop_resources_does_not_double_free(
+    ) -> Result<(), Box<dyn error::Error>> {
+        rusteron_code_gen::test_logger::init(log::LevelFilter::Info);
+
+        // --- ordering 1: close the client FIRST, then drop the resource handles ---
+        {
+            let media_driver_ctx = rusteron_media_driver::AeronDriverContext::new()?;
+            media_driver_ctx.set_dir_delete_on_shutdown(true)?;
+            media_driver_ctx.set_dir_delete_on_start(true)?;
+            media_driver_ctx.set_dir(
+                &format!("{}{}", media_driver_ctx.get_dir(), Aeron::epoch_clock()).into_c_string(),
+            )?;
+            let (stop, driver_handle) =
+                rusteron_media_driver::AeronDriver::launch_embedded(media_driver_ctx.clone(), false);
+
+            let ctx = AeronContext::new()?;
+            ctx.set_dir(&media_driver_ctx.get_dir().into_c_string())?;
+            let mut error_handler = Handler::leak(ErrorCount::default());
+            ctx.set_error_handler(Some(&error_handler))?;
+            let aeron = Aeron::new(&ctx)?;
+            aeron.start()?;
+
+            // Acquire one of every client-owned resource type and keep the handles alive.
+            let publication =
+                aeron.add_publication(&"aeron:ipc".into_c_string(), 1001, Duration::from_secs(10))?;
+            let exclusive_publication = aeron.add_exclusive_publication(
+                &"aeron:ipc".into_c_string(),
+                1002,
+                Duration::from_secs(10),
+            )?;
+            let subscription = aeron.add_subscription(
+                &"aeron:ipc".into_c_string(),
+                1003,
+                Handlers::no_available_image_handler(),
+                Handlers::no_unavailable_image_handler(),
+                Duration::from_secs(10),
+            )?;
+            let counter = aeron.add_counter(101, &[1, 2, 3, 4], "test-counter", Duration::from_secs(10))?;
+
+            // Close the client FIRST. In the C client this frees every resource above.
+            aeron.close()?;
+
+            // Dropping the still-alive handles must NOT free the (already freed) resources
+            // again. Before the fix this double-freed / used freed memory and crashed.
+            drop(publication);
+            drop(exclusive_publication);
+            drop(subscription);
+            drop(counter);
+            drop(aeron);
+
+            stop.store(true, Ordering::SeqCst);
+            let _ = driver_handle.join().unwrap();
+            error_handler.release();
+        }
+
+        // --- ordering 2: drop the resource handles FIRST, then close the client ---
+        // This is the path that always worked; it must keep working and close exactly once.
+        {
+            let media_driver_ctx = rusteron_media_driver::AeronDriverContext::new()?;
+            media_driver_ctx.set_dir_delete_on_shutdown(true)?;
+            media_driver_ctx.set_dir_delete_on_start(true)?;
+            media_driver_ctx.set_dir(
+                &format!("{}{}", media_driver_ctx.get_dir(), Aeron::epoch_clock()).into_c_string(),
+            )?;
+            let (stop, driver_handle) =
+                rusteron_media_driver::AeronDriver::launch_embedded(media_driver_ctx.clone(), false);
+
+            let ctx = AeronContext::new()?;
+            ctx.set_dir(&media_driver_ctx.get_dir().into_c_string())?;
+            let mut error_handler = Handler::leak(ErrorCount::default());
+            ctx.set_error_handler(Some(&error_handler))?;
+            let aeron = Aeron::new(&ctx)?;
+            aeron.start()?;
+
+            let publication =
+                aeron.add_publication(&"aeron:ipc".into_c_string(), 2001, Duration::from_secs(10))?;
+            let subscription = aeron.add_subscription(
+                &"aeron:ipc".into_c_string(),
+                2003,
+                Handlers::no_available_image_handler(),
+                Handlers::no_unavailable_image_handler(),
+                Duration::from_secs(10),
+            )?;
+
+            // The publication closes itself here (auto_close), exactly once.
+            assert!(!publication.is_closed());
+            drop(publication);
+            drop(subscription);
+
+            // Then the client closes; the resources are already deregistered in C.
+            aeron.close()?;
+            drop(aeron);
+
+            stop.store(true, Ordering::SeqCst);
+            let _ = driver_handle.join().unwrap();
+            error_handler.release();
+        }
+
+        Ok(())
+    }
+
     #[test]
     #[serial]
     fn blocking_add_subscription_invalid_interface_timeout() -> Result<(), Box<dyn error::Error>> {

--- a/rusteron-code-gen/src/common.rs
+++ b/rusteron-code-gen/src/common.rs
@@ -81,6 +81,24 @@ impl<T> std::fmt::Debug for CResource<T> {
     }
 }
 
+/// A type-erased, allocation-free handle to an *owning* client's "close already called"
+/// flag.
+///
+/// The Aeron C client owns every publication/subscription/counter it creates and frees
+/// them all when the client itself is closed. To avoid a double free / use-after-free,
+/// each child resource carries one of these (as a dependency) pointing at its owning
+/// client's flag. On drop the child can then cheaply ask "has my owner already been
+/// closed?" via [`ManagedCResource::owner_already_closed`] without dereferencing its own
+/// (by then freed) C pointer.
+///
+/// The pointer aliases the `close_already_called` [`std::cell::Cell`] living inside the
+/// owner's [`ManagedCResource`]. It is kept valid because the same child also holds an
+/// `Rc` dependency on the owning client (added alongside this handle), so the owner's
+/// `ManagedCResource` — and therefore the `Cell` — outlives this handle. It is only ever
+/// read from the child's `drop`, while those dependencies are still alive.
+#[derive(Clone)]
+pub struct OwnerClosed(pub *const std::cell::Cell<bool>);
+
 /// A custom struct for managing C resources with automatic cleanup.
 ///
 /// It handles initialisation and clean-up of the resource and ensures that resources
@@ -209,6 +227,30 @@ impl<T> ManagedCResource<T> {
                 .iter()
                 .filter_map(|x| x.as_ref().downcast_ref::<V>().cloned())
                 .next()
+        }
+    }
+
+    /// Returns an allocation-free handle to this resource's "close already called" flag so
+    /// it can be shared with child resources (see [`OwnerClosed`]). All clones of a wrapper
+    /// share the same underlying [`ManagedCResource`], hence the same flag, so closing the
+    /// client through any handle is observed by every child.
+    #[inline]
+    pub fn closed_indicator(&self) -> OwnerClosed {
+        OwnerClosed(&self.close_already_called as *const std::cell::Cell<bool>)
+    }
+
+    /// Returns `true` if an owning client (registered as an [`OwnerClosed`] dependency)
+    /// has already been closed. When the owning Aeron/Archive client closes it frees this
+    /// resource's underlying C memory, so the resource must neither call its own C close
+    /// fn again nor read its C pointer. This check only reads rust-side flags and never
+    /// touches the C resource, so it is safe even after the owner has freed it.
+    #[inline]
+    pub fn owner_already_closed(&self) -> bool {
+        unsafe {
+            (*self.dependencies.get())
+                .iter()
+                .filter_map(|d| d.as_ref().downcast_ref::<OwnerClosed>())
+                .any(|owner| !owner.0.is_null() && (*owner.0).get())
         }
     }
 

--- a/rusteron-code-gen/src/generator.rs
+++ b/rusteron-code-gen/src/generator.rs
@@ -562,7 +562,7 @@ impl CWrapper {
                     }
                     // This is the byte array argument - show name, type, and length
                     arg_names_for_logging.push(quote! {
-                        format!("{}: {} (len={})", #arg_name_str, stringify!(#arg_type), #arg_ident.len()) 
+                        format!("{}: {} (len={})", #arg_name_str, stringify!(#arg_type), #arg_ident.len())
                     });
                     arg_names_idx += 2;
                 }
@@ -2241,6 +2241,9 @@ pub fn generate_rust_code(
                     let var_name =
                         format_ident!("{}", e.to_string().split_whitespace().next().unwrap());
                     quote! {
+                        if let Some(__owner) = #var_name.inner.as_owned() {
+                            result.inner.add_dependency(__owner.closed_indicator());
+                        }
                         result.inner.add_dependency(#var_name.clone());
                     }
                 })
@@ -2440,14 +2443,24 @@ pub fn generate_rust_code(
                 impl Drop for #class_name {
                     fn drop(&mut self) {
                         if let Some(inner) = self.inner.as_owned() {
-                            if (inner.cleanup.is_none() ) && std::rc::Rc::strong_count(inner) == 1 && !inner.is_closed_already_called() {
-                                if inner.auto_close.get() {
-                                    log::info!("auto closing {self:?}");
-                                    let result = self.#close_method_call();
-                                    log::debug!("result {:?}", result);
-                                } else {
-                                    #[cfg(feature = "extra-logging")]
-                                    log::warn!("{} not closed", stringify!(#class_name));
+                            if (inner.cleanup.is_none() ) && std::rc::Rc::strong_count(inner) == 1 {
+                                if inner.owner_already_closed() {
+                                    // The owning client has already been closed, which in the
+                                    // Aeron C client also frees this resource. Calling our own
+                                    // close fn (or even reading the C pointer via the
+                                    // is-closed accessor) would be a double free / use-after-free.
+                                    // Just flip our rust-side flag so ManagedCResource::drop is a
+                                    // no-op and we never touch the freed pointer.
+                                    inner.close_already_called.set(true);
+                                } else if !inner.is_closed_already_called() {
+                                    if inner.auto_close.get() {
+                                        log::info!("auto closing {self:?}");
+                                        let result = self.#close_method_call();
+                                        log::debug!("result {:?}", result);
+                                    } else {
+                                        #[cfg(feature = "extra-logging")]
+                                        log::warn!("{} not closed", stringify!(#class_name));
+                                    }
                                 }
                             }
                         }

--- a/rusteron-media-driver/docs-rs/aeron.rs
+++ b/rusteron-media-driver/docs-rs/aeron.rs
@@ -205,6 +205,23 @@ impl<T> std::fmt::Debug for CResource<T> {
         }
     }
 }
+#[doc = " A type-erased, allocation-free handle to an *owning* client's \"close already called\""]
+#[doc = " flag."]
+#[doc = ""]
+#[doc = " The Aeron C client owns every publication/subscription/counter it creates and frees"]
+#[doc = " them all when the client itself is closed. To avoid a double free / use-after-free,"]
+#[doc = " each child resource carries one of these (as a dependency) pointing at its owning"]
+#[doc = " client's flag. On drop the child can then cheaply ask \"has my owner already been"]
+#[doc = " closed?\" via [`ManagedCResource::owner_already_closed`] without dereferencing its own"]
+#[doc = " (by then freed) C pointer."]
+#[doc = ""]
+#[doc = " The pointer aliases the `close_already_called` [`std::cell::Cell`] living inside the"]
+#[doc = " owner's [`ManagedCResource`]. It is kept valid because the same child also holds an"]
+#[doc = " `Rc` dependency on the owning client (added alongside this handle), so the owner's"]
+#[doc = " `ManagedCResource` — and therefore the `Cell` — outlives this handle. It is only ever"]
+#[doc = " read from the child's `drop`, while those dependencies are still alive."]
+#[derive(Clone)]
+pub struct OwnerClosed(pub *const std::cell::Cell<bool>);
 #[doc = " A custom struct for managing C resources with automatic cleanup."]
 #[doc = ""]
 #[doc = " It handles initialisation and clean-up of the resource and ensures that resources"]
@@ -321,6 +338,28 @@ impl<T> ManagedCResource<T> {
                 .iter()
                 .filter_map(|x| x.as_ref().downcast_ref::<V>().cloned())
                 .next()
+        }
+    }
+    #[doc = " Returns an allocation-free handle to this resource's \"close already called\" flag so"]
+    #[doc = " it can be shared with child resources (see [`OwnerClosed`]). All clones of a wrapper"]
+    #[doc = " share the same underlying [`ManagedCResource`], hence the same flag, so closing the"]
+    #[doc = " client through any handle is observed by every child."]
+    #[inline]
+    pub fn closed_indicator(&self) -> OwnerClosed {
+        OwnerClosed(&self.close_already_called as *const std::cell::Cell<bool>)
+    }
+    #[doc = " Returns `true` if an owning client (registered as an [`OwnerClosed`] dependency)"]
+    #[doc = " has already been closed. When the owning Aeron/Archive client closes it frees this"]
+    #[doc = " resource's underlying C memory, so the resource must neither call its own C close"]
+    #[doc = " fn again nor read its C pointer. This check only reads rust-side flags and never"]
+    #[doc = " touches the C resource, so it is safe even after the owner has freed it."]
+    #[inline]
+    pub fn owner_already_closed(&self) -> bool {
+        unsafe {
+            (*self.dependencies.get())
+                .iter()
+                .filter_map(|d| d.as_ref().downcast_ref::<OwnerClosed>())
+                .any(|owner| !owner.0.is_null() && (*owner.0).get())
         }
     }
     #[inline]
@@ -2235,6 +2274,9 @@ impl AeronAsyncAddCounter {
         let result = Self {
             inner: CResource::OwnedOnHeap(std::rc::Rc::new(resource_async)),
         };
+        if let Some(__owner) = client.inner.as_owned() {
+            result.inner.add_dependency(__owner.closed_indicator());
+        }
         result.inner.add_dependency(client.clone());
         Ok(result)
     }
@@ -2577,6 +2619,9 @@ impl AeronAsyncAddExclusivePublication {
         let result = Self {
             inner: CResource::OwnedOnHeap(std::rc::Rc::new(resource_async)),
         };
+        if let Some(__owner) = client.inner.as_owned() {
+            result.inner.add_dependency(__owner.closed_indicator());
+        }
         result.inner.add_dependency(client.clone());
         Ok(result)
     }
@@ -2887,6 +2932,9 @@ impl AeronAsyncAddPublication {
         let result = Self {
             inner: CResource::OwnedOnHeap(std::rc::Rc::new(resource_async)),
         };
+        if let Some(__owner) = client.inner.as_owned() {
+            result.inner.add_dependency(__owner.closed_indicator());
+        }
         result.inner.add_dependency(client.clone());
         Ok(result)
     }
@@ -3265,6 +3313,9 @@ impl AeronAsyncAddSubscription {
         let result = Self {
             inner: CResource::OwnedOnHeap(std::rc::Rc::new(resource_async)),
         };
+        if let Some(__owner) = client.inner.as_owned() {
+            result.inner.add_dependency(__owner.closed_indicator());
+        }
         result.inner.add_dependency(client.clone());
         Ok(result)
     }
@@ -11490,17 +11541,18 @@ impl From<aeron_counter_t> for AeronCounter {
 impl Drop for AeronCounter {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close_with_no_args();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!("{} not closed", stringify!(AeronCounter));
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close_with_no_args();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!("{} not closed", stringify!(AeronCounter));
+                    }
                 }
             }
         }
@@ -33935,17 +33987,18 @@ impl From<aeron_exclusive_publication_t> for AeronExclusivePublication {
 impl Drop for AeronExclusivePublication {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close_with_no_args();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!("{} not closed", stringify!(AeronExclusivePublication));
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close_with_no_args();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!("{} not closed", stringify!(AeronExclusivePublication));
+                    }
                 }
             }
         }
@@ -52761,17 +52814,18 @@ impl From<aeron_publication_t> for AeronPublication {
 impl Drop for AeronPublication {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close_with_no_args();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!("{} not closed", stringify!(AeronPublication));
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close_with_no_args();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!("{} not closed", stringify!(AeronPublication));
+                    }
                 }
             }
         }
@@ -54986,17 +55040,18 @@ impl From<aeron_receive_channel_endpoint_t> for AeronReceiveChannelEndpoint {
 impl Drop for AeronReceiveChannelEndpoint {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!("{} not closed", stringify!(AeronReceiveChannelEndpoint));
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!("{} not closed", stringify!(AeronReceiveChannelEndpoint));
+                    }
                 }
             }
         }
@@ -58876,17 +58931,18 @@ impl From<aeron_send_channel_endpoint_t> for AeronSendChannelEndpoint {
 impl Drop for AeronSendChannelEndpoint {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!("{} not closed", stringify!(AeronSendChannelEndpoint));
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!("{} not closed", stringify!(AeronSendChannelEndpoint));
+                    }
                 }
             }
         }
@@ -63405,17 +63461,18 @@ impl From<aeron_subscription_t> for AeronSubscription {
 impl Drop for AeronSubscription {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close_with_no_args();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!("{} not closed", stringify!(AeronSubscription));
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close_with_no_args();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!("{} not closed", stringify!(AeronSubscription));
+                    }
                 }
             }
         }
@@ -72278,17 +72335,18 @@ impl From<aeron_uri_t> for AeronUri {
 impl Drop for AeronUri {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_owned() {
-            if (inner.cleanup.is_none())
-                && std::rc::Rc::strong_count(inner) == 1
-                && !inner.is_closed_already_called()
-            {
-                if inner.auto_close.get() {
-                    log::info!("auto closing {self:?}");
-                    let result = self.close();
-                    log::debug!("result {:?}", result);
-                } else {
-                    #[cfg(feature = "extra-logging")]
-                    log::warn!("{} not closed", stringify!(AeronUri));
+            if (inner.cleanup.is_none()) && std::rc::Rc::strong_count(inner) == 1 {
+                if inner.owner_already_closed() {
+                    inner.close_already_called.set(true);
+                } else if !inner.is_closed_already_called() {
+                    if inner.auto_close.get() {
+                        log::info!("auto closing {self:?}");
+                        let result = self.close();
+                        log::debug!("result {:?}", result);
+                    } else {
+                        #[cfg(feature = "extra-logging")]
+                        log::warn!("{} not closed", stringify!(AeronUri));
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Problem

Closing an `Aeron`/`AeronArchive` client while a publication, exclusive publication,
subscription, or counter handle is still alive crashed on shutdown:

- Linux/glibc: `free(): double free detected in tcache 2`
- macOS: SIGSEGV / SIGABRT when the handle drops

```rust
let publication = aeron.add_publication(&"aeron:ipc".into_c_string(), 1001, timeout)?;
aeron.close()?;     // C client frees the publication here
drop(publication);  // rusteron freed it AGAIN -> double free
```

Dropping the handle before `aeron.close()` always worked.

## Cause

The Aeron C client owns every resource and frees them all on `aeron_close`. rusteron also
freed each resource on Rust handle drop, so the close-first ordering freed it twice. The
existing `Drop` guard didn't catch this. Worse, it read the already-freed C pointer
(`aeron_publication_is_closed`) to decide whether to close, which is a use-after-free on its
own.

### Likely upstream trigger

This looks like it was surfaced by a change in the Aeron 1.51 C client
([CHANGELOG.adoc](https://github.com/aeron-io/aeron/blob/master/CHANGELOG.adoc)):

> **Breaking: [Client/C]** Removed `aeron_async_cmd_free` method.
>
> Async structs (e.g. `aeron_async_add_subscription_t`) are freed automatically when:
> - the poll call (e.g. `aeron_async_add_subscription_poll`) completes, i.e. resource is created, errored or timed out;
> - resource creation is canceled without polling (e.g. `aeron_async_add_subscription_cancel`);
> - resource removal is invoked without polling (e.g. `aeron_async_remove_subscription`);
> - `aeron_client_t` is closed.

The C client now owns and frees these on close, so rusteron freeing them again on handle
drop is a double free.

A couple of other 1.51 entries point the same way:

> **Breaking: [Client/C++ Wrapper]** Remove `close()` method from `Publication/ExclusivePublication`,
> i.e. the underlying `aeron_publication_t/aeron_exclusive_publication_t` will be closed when the
> corresponding C++ object is destroyed.

> **[C]** Fix use-after-free issue when removing pending close resource fails to submit delete
> command to the media driver, i.e. perform a single shot close action just like a normal close
> command would.

The first one is upstream's own C++ wrapper dropping its explicit `close()` and tying the
close to object destruction, which is the same model this PR moves rusteron to. The second
shows the C close path itself was reworked in 1.51, which lines up with the behavior change
that exposed the double free.

## Fix

In `rusteron-code-gen` (then regenerated):

1. Each child carries a zero-alloc `OwnerClosed` pointer to its owning client's "closed"
   flag, registered next to the existing `Rc<Aeron>` dependency that keeps the owner alive.
2. The generated `Drop` checks `owner_already_closed()` first. If the owner already closed
   (and freed us in C), it just marks itself released and skips the C close, so it never
   touches the freed pointer.

Drop-first ordering is unchanged (closes exactly once, no leak). This applies to all four
resource types and to the archive crate.

--- 

I'm very open to feedback. If this is the wrong fix I'm happy to change it, just point me
in the right direction. 
