### PR TITLE
Fix static linking on Linux

### DIFF
--- a/rusteron-archive/build_common.rs
+++ b/rusteron-archive/build_common.rs
@@ -77,13 +77,7 @@ impl LinkType {
     fn link_lib(&self) -> &'static str {
         match self {
             LinkType::Dynamic => "dylib=",
-            LinkType::Static => {
-                if cfg!(target_os = "linux") {
-                    "" // TODO not sure why I need to do this static= should work on linux based on documentation
-                } else {
-                    "static="
-                }
-            }
+            LinkType::Static => "static=",
         }
     }
 
@@ -254,11 +248,9 @@ fn build_from_source(config: &RusteronBuildConfig, docs_rs: &Path) {
     let mut cmake_config = Config::new(&aeron_path);
     if std::env::var("PROFILE").unwrap() == "release" {
         cmake_config.profile("Release");
-        let release_flags = if publish_binaries {
-            "-O3 -DNDEBUG -march=native -funroll-loops"
-        } else {
-            "-O3 -DNDEBUG -march=native -funroll-loops -flto"
-        };
+        // No -flto: cmake uses GCC which produces GCC LTO archives; rust-lld (LLVM)
+        // cannot link GCC LTO bitcode, causing undefined symbols at link time.
+        let release_flags = "-O3 -DNDEBUG -march=native -funroll-loops";
         cmake_config.define("CMAKE_CXX_FLAGS_RELEASE", release_flags);
         cmake_config.define("CMAKE_C_FLAGS_RELEASE", release_flags);
     } else {

--- a/rusteron-archive/build_common.rs
+++ b/rusteron-archive/build_common.rs
@@ -212,8 +212,6 @@ fn build_from_source(config: &RusteronBuildConfig, docs_rs: &Path) {
     use proc_macro2::TokenStream;
     use rusteron_code_gen::{append_to_file, format_with_rustfmt};
 
-    let publish_binaries = std::env::var("PUBLISH_ARTIFACTS").is_ok();
-
     if pkg_config::probe_library("uuid").is_err() {
         eprintln!("uuid lib not found in path");
     }

--- a/rusteron-client/build_common.rs
+++ b/rusteron-client/build_common.rs
@@ -77,13 +77,7 @@ impl LinkType {
     fn link_lib(&self) -> &'static str {
         match self {
             LinkType::Dynamic => "dylib=",
-            LinkType::Static => {
-                if cfg!(target_os = "linux") {
-                    "" // TODO not sure why I need to do this static= should work on linux based on documentation
-                } else {
-                    "static="
-                }
-            }
+            LinkType::Static => "static=",
         }
     }
 
@@ -254,11 +248,9 @@ fn build_from_source(config: &RusteronBuildConfig, docs_rs: &Path) {
     let mut cmake_config = Config::new(&aeron_path);
     if std::env::var("PROFILE").unwrap() == "release" {
         cmake_config.profile("Release");
-        let release_flags = if publish_binaries {
-            "-O3 -DNDEBUG -march=native -funroll-loops"
-        } else {
-            "-O3 -DNDEBUG -march=native -funroll-loops -flto"
-        };
+        // No -flto: cmake uses GCC which produces GCC LTO archives; rust-lld (LLVM)
+        // cannot link GCC LTO bitcode, causing undefined symbols at link time.
+        let release_flags = "-O3 -DNDEBUG -march=native -funroll-loops";
         cmake_config.define("CMAKE_CXX_FLAGS_RELEASE", release_flags);
         cmake_config.define("CMAKE_C_FLAGS_RELEASE", release_flags);
     } else {

--- a/rusteron-client/build_common.rs
+++ b/rusteron-client/build_common.rs
@@ -212,8 +212,6 @@ fn build_from_source(config: &RusteronBuildConfig, docs_rs: &Path) {
     use proc_macro2::TokenStream;
     use rusteron_code_gen::{append_to_file, format_with_rustfmt};
 
-    let publish_binaries = std::env::var("PUBLISH_ARTIFACTS").is_ok();
-
     if pkg_config::probe_library("uuid").is_err() {
         eprintln!("uuid lib not found in path");
     }

--- a/rusteron-code-gen/src/build_common.rs
+++ b/rusteron-code-gen/src/build_common.rs
@@ -77,13 +77,7 @@ impl LinkType {
     fn link_lib(&self) -> &'static str {
         match self {
             LinkType::Dynamic => "dylib=",
-            LinkType::Static => {
-                if cfg!(target_os = "linux") {
-                    "" // TODO not sure why I need to do this static= should work on linux based on documentation
-                } else {
-                    "static="
-                }
-            }
+            LinkType::Static => "static=",
         }
     }
 
@@ -254,11 +248,9 @@ fn build_from_source(config: &RusteronBuildConfig, docs_rs: &Path) {
     let mut cmake_config = Config::new(&aeron_path);
     if std::env::var("PROFILE").unwrap() == "release" {
         cmake_config.profile("Release");
-        let release_flags = if publish_binaries {
-            "-O3 -DNDEBUG -march=native -funroll-loops"
-        } else {
-            "-O3 -DNDEBUG -march=native -funroll-loops -flto"
-        };
+        // No -flto: cmake uses GCC which produces GCC LTO archives; rust-lld (LLVM)
+        // cannot link GCC LTO bitcode, causing undefined symbols at link time.
+        let release_flags = "-O3 -DNDEBUG -march=native -funroll-loops";
         cmake_config.define("CMAKE_CXX_FLAGS_RELEASE", release_flags);
         cmake_config.define("CMAKE_C_FLAGS_RELEASE", release_flags);
     } else {

--- a/rusteron-media-driver/build_common.rs
+++ b/rusteron-media-driver/build_common.rs
@@ -77,13 +77,7 @@ impl LinkType {
     fn link_lib(&self) -> &'static str {
         match self {
             LinkType::Dynamic => "dylib=",
-            LinkType::Static => {
-                if cfg!(target_os = "linux") {
-                    "" // TODO not sure why I need to do this static= should work on linux based on documentation
-                } else {
-                    "static="
-                }
-            }
+            LinkType::Static => "static=",
         }
     }
 
@@ -254,11 +248,9 @@ fn build_from_source(config: &RusteronBuildConfig, docs_rs: &Path) {
     let mut cmake_config = Config::new(&aeron_path);
     if std::env::var("PROFILE").unwrap() == "release" {
         cmake_config.profile("Release");
-        let release_flags = if publish_binaries {
-            "-O3 -DNDEBUG -march=native -funroll-loops"
-        } else {
-            "-O3 -DNDEBUG -march=native -funroll-loops -flto"
-        };
+        // No -flto: cmake uses GCC which produces GCC LTO archives; rust-lld (LLVM)
+        // cannot link GCC LTO bitcode, causing undefined symbols at link time.
+        let release_flags = "-O3 -DNDEBUG -march=native -funroll-loops";
         cmake_config.define("CMAKE_CXX_FLAGS_RELEASE", release_flags);
         cmake_config.define("CMAKE_C_FLAGS_RELEASE", release_flags);
     } else {

--- a/rusteron-media-driver/build_common.rs
+++ b/rusteron-media-driver/build_common.rs
@@ -212,8 +212,6 @@ fn build_from_source(config: &RusteronBuildConfig, docs_rs: &Path) {
     use proc_macro2::TokenStream;
     use rusteron_code_gen::{append_to_file, format_with_rustfmt};
 
-    let publish_binaries = std::env::var("PUBLISH_ARTIFACTS").is_ok();
-
     if pkg_config::probe_library("uuid").is_err() {
         eprintln!("uuid lib not found in path");
     }


### PR DESCRIPTION
Two bugs in `build_common.rs` combined to break static linking when building with the `release` profile on Linux.

## Bug 1 - wrong cargo link prefix

`link_lib()` returned an empty prefix for `LinkType::Static` on Linux, so cargo emitted `cargo:rustc-link-lib=aeron_static` instead of `cargo:rustc-link-lib=static=aeron_static`. Without the prefix cargo treats the library as dynamic, so the Aeron `.a` files ended up in the `-Wl,-Bdynamic` section of the linker command.

## Bug 2 - GCC LTO archives incompatible with rust-lld

When `PROFILE=release`, cmake was compiled with `-flto`. The C compiler that we use in CI is GCC (via `sccache cc`), so `-flto` produces GCC LTO bitcode archives rather than regular object archives.

`rust-lld` is LLVM's linker. It cannot process GCC LTO bitcode. So whether the Aeron `.a` files were in the dynamic section (bug 1) or the static section, lld could not read them and reported undefined symbols (`aeron_context_init` etc.).

Bug 1 was masked in `debug` profile builds because cmake used the Debug profile there (no `-flto`), producing regular archives that lld can fall back to even from the dynamic section.

## Fix

- `link_lib()` now always returns `"static="` for `LinkType::Static`
- `-flto` removed from cmake Release flags; the flag is not useful here anyway since Rust drives its own LTO separately and lld would need to re-process the C objects at link time to benefit from it
